### PR TITLE
docs: improve Spanish quick start guide

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,143 +1,155 @@
-# Quick Start Guide
+# Guía rápida de MindMapper
 
-## Verificación del Proyecto
+Esta guía explica los primeros pasos sin entrar en detalles técnicos. Sirve para abrir la aplicación, crear un primer mapa mental, guardarlo y compartirlo.
 
-El proyecto ha sido configurado y verificado correctamente. Todos los archivos de TypeScript se compilan sin errores.
+## 1. Abrir MindMapper
 
-### ✅ Verificado
+Si solo quieres usar la aplicación:
 
-- ✅ Estructura de carpetas creada
-- ✅ Dependencias instaladas (390 paquetes)
-- ✅ TypeScript configurado correctamente para main, renderer y preload
-- ✅ Build exitoso (`npm run build`)
-- ✅ Electron configurado con seguridad estricta
-- ✅ React + Vite configurado
-- ✅ Preload script con APIs IPC tipadas
-- ✅ Git inicializado con commit inicial
+1. Ve a la página de [Releases](https://github.com/Juan-31416/MindMapper/releases).
+2. Descarga el instalador de tu sistema:
+   - Windows: archivo `MindMapper Setup.exe`.
+   - macOS: archivo `.dmg`.
+   - Linux: archivo `.AppImage` o `.deb`.
+3. Abre el instalador o ejecutable y sigue los pasos habituales de tu sistema.
 
-### 🚀 Cómo Ejecutar
+Si vas a trabajar desde el código fuente, consulta [Ejecutar desde el código fuente](#ejecutar-desde-el-código-fuente).
 
-Para ejecutar la aplicación en modo desarrollo:
+## 2. Crear tu primer mapa
+
+Al abrir MindMapper verás un mapa inicial de bienvenida. Puedes usarlo para practicar o crear uno nuevo.
+
+Para crear un mapa sencillo:
+
+1. Pulsa **New** para crear un mapa nuevo.
+2. Escribe la idea principal en el nodo central.
+3. Selecciona el nodo central y pulsa `Tab` para crear una idea hija.
+4. Pulsa `Enter` para crear otra idea al mismo nivel.
+5. Haz doble clic en cualquier nodo para cambiar su texto.
+
+Ejemplo:
+
+```text
+Planificar vacaciones
+├── Destino
+├── Presupuesto
+├── Transporte
+└── Actividades
+```
+
+## 3. Moverse por el mapa
+
+- Arrastra el fondo del mapa para moverte por el lienzo.
+- Usa el zoom para acercarte o alejarte cuando el mapa crezca.
+- Pulsa `Ctrl+1` para ajustar el mapa completo a la pantalla.
+- Colapsa ramas cuando quieras ocultar detalles y centrarte en una parte.
+
+## 4. Editar y organizar ideas
+
+Las acciones básicas son:
+
+| Acción | Cómo hacerlo |
+| --- | --- |
+| Crear una idea hija | Selecciona un nodo y pulsa `Tab` |
+| Crear una idea hermana | Selecciona un nodo y pulsa `Enter` |
+| Cambiar el texto | Haz doble clic sobre el nodo |
+| Borrar un nodo | Selecciónalo y pulsa `Delete` o `Backspace` |
+| Deshacer | Pulsa `Ctrl+Z` |
+| Rehacer | Pulsa `Ctrl+Y` |
+
+También puedes usar la barra lateral para cambiar colores, bordes, iconos y otros estilos del nodo seleccionado.
+
+## 5. Guardar y abrir mapas
+
+Para no perder tu trabajo:
+
+- Pulsa `Ctrl+S` para guardar.
+- Usa **Save As** o `Ctrl+Shift+S` si quieres guardar una copia con otro nombre.
+- Los mapas se guardan como archivos `.mindmap.json`.
+- Para abrir un mapa existente, usa **Open** o `Ctrl+O`.
+
+Consejo: guarda tus mapas en una carpeta sincronizada, como OneDrive, Google Drive o Dropbox, si quieres tener una copia de seguridad sencilla.
+
+## 6. Exportar o compartir
+
+MindMapper permite exportar mapas para compartirlos fuera de la aplicación:
+
+- Exporta a PDF cuando quieras enviar o imprimir el mapa.
+- Exporta a JSON cuando quieras guardar una copia editable o compartirla con otra persona que use MindMapper.
+
+## 7. Importar un esquema Markdown
+
+Si ya tienes una lista de ideas en Markdown, puedes importarla como mapa mental.
+
+Ejemplo de archivo Markdown:
+
+```markdown
+# Proyecto
+## Objetivos
+## Tareas
+### Diseño
+### Desarrollo
+### Revisión
+```
+
+Al importarlo, MindMapper convierte los títulos en nodos organizados por niveles.
+
+## 8. Ejecutar desde el código fuente
+
+Esta sección es para personas que quieren probar o modificar el proyecto.
+
+Requisitos:
+
+- Node.js 18 o superior.
+- npm.
+
+Pasos:
 
 ```bash
-cd /home/ubuntu/mindmapper
+git clone https://github.com/Juan-31416/MindMapper.git
+cd MindMapper
+npm install
 npm run dev
 ```
 
-Esto iniciará:
-1. El servidor de desarrollo de Vite en `http://localhost:5173`
-2. La aplicación Electron que cargará el contenido de Vite
-3. Las DevTools se abrirán automáticamente
-
-### 📦 Cómo Empaquetar
-
-Para crear un ejecutable:
-
-```bash
-# Para la plataforma actual
-npm run package
-
-# O para plataformas específicas
-npm run package:win      # Windows
-npm run package:mac      # macOS
-npm run package:linux    # Linux
-```
-
-Los ejecutables se guardarán en la carpeta `build/`.
-
-### 🔍 Verificar Build
-
-Para verificar que todo compila correctamente:
+Para comprobar que el proyecto compila:
 
 ```bash
 npm run build
 ```
 
-Este comando:
-1. Compila TypeScript del renderer con `tsc`
-2. Bundlea React con Vite
-3. Compila TypeScript del main process
-4. Compila TypeScript del preload script
+Para crear un paquete instalable para tu sistema:
 
-### 🛠️ Estructura del Proyecto
-
-```
-mindmapper/
-├── src/
-│   ├── main/
-│   │   └── main.ts              # Proceso principal de Electron
-│   ├── preload/
-│   │   └── preload.ts           # Bridge seguro IPC
-│   └── renderer/
-│       ├── components/          # Componentes React (vacío por ahora)
-│       ├── store/
-│       │   └── mindMapStore.ts  # Store de Zustand
-│       ├── styles/
-│       │   ├── App.css          # Estilos del App
-│       │   └── index.css        # Estilos globales
-│       ├── types/
-│       │   └── electron.d.ts    # Tipos para Electron API
-│       ├── App.tsx              # Componente principal
-│       ├── main.tsx             # Entry point de React
-│       └── index.html           # HTML template
-├── dist/                        # Build output
-├── node_modules/                # Dependencias (390 paquetes)
-├── package.json                 # Configuración del proyecto
-├── tsconfig.*.json              # Configuraciones TypeScript
-├── vite.config.ts               # Configuración de Vite
-└── README.md                    # Documentación principal
+```bash
+npm run package
 ```
 
-### 🔒 Seguridad
+## 9. Problemas frecuentes
 
-La aplicación implementa todas las mejores prácticas de seguridad de Electron:
+### `npm run dev` no abre la aplicación
 
-- ✅ `contextIsolation: true` - Aisla el contexto del preload
-- ✅ `sandbox: true` - Habilita el sandbox de Chrome
-- ✅ `nodeIntegration: false` - Deshabilita Node.js en el renderer
-- ✅ Preload script tipado - APIs seguras expuestas mediante IPC
+Comprueba que las dependencias están instaladas:
 
-### 📝 Notas
+```bash
+npm install
+```
 
-- El proyecto usa **Electron 28**, **React 18**, **TypeScript 5** y **Vite 5**
-- Todas las comunicaciones entre procesos usan IPC handlers seguros
-- Los tipos están completamente definidos en `electron.d.ts`
-- El estado se maneja con Zustand (store minimalista por ahora)
-- Los iconos vienen de Lucide React
-- Dagre está instalado para futuros algoritmos de layout
+Después vuelve a ejecutar:
 
-### 🎯 Próximos Pasos (Fase 2)
+```bash
+npm run dev
+```
 
-El scaffold está completo. Las siguientes fases incluirán:
+### El puerto 5173 está ocupado
 
-1. **Canvas de Mind Map**: Implementar el área de trabajo con zoom y pan
-2. **Sistema de Nodos**: Crear, editar y eliminar nodos
-3. **Conexiones**: Conectar nodos con líneas/flechas
-4. **Persistencia**: Guardar y cargar archivos .mindmap
-5. **Layout Automático**: Usar Dagre para organizar nodos
-6. **Temas**: Modo claro/oscuro
-7. **Atajos de teclado**: Mejoras de UX
-8. **Export**: Exportar a PNG, SVG, PDF
+Cierra otras aplicaciones de desarrollo que puedan estar usando ese puerto y vuelve a intentarlo.
 
-### ❓ Troubleshooting
+### No puedo borrar un nodo
 
-Si `npm run dev` no funciona:
+El nodo principal del mapa no se puede borrar. Selecciona otro nodo y prueba de nuevo con `Delete` o `Backspace`.
 
-1. Asegúrate de que el puerto 5173 esté libre
-2. Verifica que Node.js sea versión 18+: `node --version`
-3. Reinstala dependencias: `rm -rf node_modules && npm install`
-4. Verifica que el build funciona: `npm run build`
+## 10. Más ayuda
 
-Si Electron no abre:
-
-1. En Linux, puede requerir permisos adicionales
-2. Asegúrate de tener un entorno gráfico disponible
-3. Verifica los logs en la consola
-
-### 📚 Recursos
-
-- [Electron Documentation](https://www.electronjs.org/docs)
-- [React Documentation](https://react.dev)
-- [Vite Documentation](https://vitejs.dev)
-- [Zustand Documentation](https://github.com/pmndrs/zustand)
-- [Electron Security Guide](https://www.electronjs.org/docs/latest/tutorial/security)
+- Consulta [USAGE.md](./USAGE.md) para una guía completa de uso.
+- Consulta [DATA_SCHEMA.md](./DATA_SCHEMA.md) si quieres entender el formato de los archivos `.mindmap.json`.
+- Abre un issue en GitHub si encuentras un error o tienes una sugerencia.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ chmod +x MindMapper*.AppImage
 
 **Linux (Debian/Ubuntu):**
 ```bash
-sudo dpgk -i mindmapper*.deb
+sudo dpkg -i mindmapper*.deb
 ```
 
 **Windows**: Run MindMapper Setup.exe and follow the installer.
@@ -82,8 +82,8 @@ sudo dpgk -i mindmapper*.deb
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/yourusername/mindmapper.git
-cd mindmapper
+git clone https://github.com/Juan-31416/MindMapper.git
+cd MindMapper
 ```
 
 2. Install dependencies:
@@ -116,6 +116,8 @@ npm run package      # build for current platform
 4. **Customize** - Use the right sidebar to change colors, icons, and styles
 5. **Save your work** - Press `Ctrl+S` to save your mind map
 6. **Export** - Export to PDF or JSON from the File menu
+
+For a beginner-friendly first-use guide in Spanish, see [QUICKSTART.md](./QUICKSTART.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- Rewrite QUICKSTART.md as a beginner-friendly Spanish first-use guide.
- Add a README link to the quick start guide.
- Fix two small README install/source examples.

Closes #16.

## Validation
- Ran `git diff --check`.
- Checked local Markdown links in README.md and QUICKSTART.md.
- Cross-checked documented shortcuts/actions against USAGE.md and the app code.